### PR TITLE
添加 vit 模型和一些复现常用的功能代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,37 +13,3 @@ Recent Transformer-based CV and related works on PaddlePaddle 2.0
 | 06 | Token Labeling: Training a 85.4% Top-1 Accuracy Vision Transformer with 56M Parameters on ImageNet |
 | 07 | Big Transfer (BiT): General Visual Representation Learning|
 | 08 | Going deeper with Image Transformers |
-
-## 常用功能模块
-* 在 utils 包中包含一些常用的功能模块
-* 下面为简单介绍，具体用法可以参考 Vision Transformer/vit.py
-### 网络层
-* Identity：占位层
-* DropPath：一种 Dropout 层
-### 常用函数
-* to_2tuple：int(x) -> (int(x), int(x))
-* add_parameter：创建可学习参数
-```python
-# Paddle
-from utils import add_parameter
-
-class VisionTransformer(nn.Layer):
-    def __init__(self):
-        super().__init__()
-        self.pos_embed = add_parameter(self, paddle.zeros((1, num_patches + 1, embed_dim)))
-
-
-# Pytorch
-class VisionTransformer(nn.Layer):
-    def __init__(self):
-        super().__init__()
-        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
-```
-### 常用初始化
-* ones_：全一初始化
-* zeros_：全零初始化
-* trunc_normal_：trunc_normal 初始化（std=0.2）
-```python
-from utils import zeros_
-zeros_(layer.bias)
-```

--- a/README.md
+++ b/README.md
@@ -13,3 +13,37 @@ Recent Transformer-based CV and related works on PaddlePaddle 2.0
 | 06 | Token Labeling: Training a 85.4% Top-1 Accuracy Vision Transformer with 56M Parameters on ImageNet |
 | 07 | Big Transfer (BiT): General Visual Representation Learning|
 | 08 | Going deeper with Image Transformers |
+
+## 常用功能模块
+* 在 utils 包中包含一些常用的功能模块
+* 下面为简单介绍，具体用法可以参考 Vision Transformer/vit.py
+### 网络层
+* Identity：占位层
+* DropPath：一种 Dropout 层
+### 常用函数
+* to_2tuple：int(x) -> (int(x), int(x))
+* add_parameter：创建可学习参数
+```python
+# Paddle
+from utils import add_parameter
+
+class VisionTransformer(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.pos_embed = add_parameter(self, paddle.zeros((1, num_patches + 1, embed_dim)))
+
+
+# Pytorch
+class VisionTransformer(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
+```
+### 常用初始化
+* ones_：全一初始化
+* zeros_：全零初始化
+* trunc_normal_：trunc_normal 初始化（std=0.2）
+```python
+from utils import zeros_
+zeros_(layer.bias)
+```

--- a/Vision Transformer/vit.py
+++ b/Vision Transformer/vit.py
@@ -1,0 +1,227 @@
+# --------------------------------------------------------------------------
+# Vision Transformer in PaddlePaddle
+# Paper: https://arxiv.org/pdf/2010.11929.pdf
+# --------------------------------------------------------------------------
+
+import numpy as np
+
+import paddle
+import paddle.nn as nn
+from ..utils.common import to_2tuple, add_parameter
+from ..utils.common import trunc_normal_, zeros_, ones_
+from ..utils.common import Identity, DropPath
+
+
+class Mlp(nn.Layer):
+    def __init__(self,
+                 in_features,
+                 hidden_features=None,
+                 out_features=None,
+                 act_layer=nn.GELU,
+                 drop=0.):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+
+class Attention(nn.Layer):
+    def __init__(self,
+                 dim,
+                 num_heads=8,
+                 qkv_bias=False,
+                 qk_scale=None,
+                 attn_drop=0.,
+                 proj_drop=0.):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias_attr=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x):
+        # B= paddle.shape(x)[0]
+        N, C = x.shape[1:]
+        qkv = self.qkv(x).reshape((-1, N, 3, self.num_heads, C //
+                                   self.num_heads)).transpose((2, 0, 3, 1, 4))
+        q, k, v = qkv[0], qkv[1], qkv[2]
+
+        attn = (q.matmul(k.transpose((0, 1, 3, 2)))) * self.scale
+        attn = nn.functional.softmax(attn, axis=-1)
+        attn = self.attn_drop(attn)
+
+        x = (attn.matmul(v)).transpose((0, 2, 1, 3)).reshape((-1, N, C))
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+
+class Block(nn.Layer):
+    def __init__(self,
+                 dim,
+                 num_heads,
+                 mlp_ratio=4.,
+                 qkv_bias=False,
+                 qk_scale=None,
+                 drop=0.,
+                 attn_drop=0.,
+                 drop_path=0.,
+                 act_layer=nn.GELU,
+                 norm_layer=nn.LayerNorm,
+                 epsilon=1e-5):
+        super().__init__()
+        self.norm1 = norm_layer(dim, epsilon=epsilon)
+        self.attn = Attention(
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+            attn_drop=attn_drop,
+            proj_drop=drop)
+        # NOTE: drop path for stochastic depth, we shall see if this is better than dropout here
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else Identity()
+        self.norm2 = norm_layer(dim, epsilon=epsilon)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(in_features=dim,
+                       hidden_features=mlp_hidden_dim,
+                       act_layer=act_layer,
+                       drop=drop)
+
+    def forward(self, x):
+        x = x + self.drop_path(self.attn(self.norm1(x)))
+        x = x + self.drop_path(self.mlp(self.norm2(x)))
+        return x
+
+
+class PatchEmbed(nn.Layer):
+    def __init__(self, img_size=224, patch_size=16, in_chans=3, embed_dim=768):
+        super().__init__()
+        img_size = to_2tuple(img_size)
+        patch_size = to_2tuple(patch_size)
+        num_patches = (img_size[1] // patch_size[1]) * \
+            (img_size[0] // patch_size[0])
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.num_patches = num_patches
+
+        self.proj = nn.Conv2D(
+            in_chans, embed_dim, kernel_size=patch_size, stride=patch_size)
+
+    def forward(self, x):
+        B, C, H, W = x.shape
+        assert H == self.img_size[0] and W == self.img_size[1], \
+            "Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]})."
+
+        x = self.proj(x).flatten(2).transpose((0, 2, 1))
+        return x
+
+
+class VisionTransformer(nn.Layer):
+    def __init__(self,
+                 img_size=224,
+                 patch_size=16,
+                 in_chans=3,
+                 embed_dim=768,
+                 depth=12,
+                 num_heads=12,
+                 mlp_ratio=4,
+                 qkv_bias=False,
+                 qk_scale=None,
+                 drop_rate=0.,
+                 attn_drop_rate=0.,
+                 drop_path_rate=0.,
+                 norm_layer=nn.LayerNorm,
+                 epsilon=1e-5,
+                 class_dim=1000):
+        super().__init__()
+        self.class_dim = class_dim
+        self.num_features = self.embed_dim = embed_dim
+
+        self.patch_embed = PatchEmbed(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim)
+        num_patches = self.patch_embed.num_patches
+
+        self.pos_embed = add_parameter(
+            self, paddle.zeros((1, num_patches + 1, embed_dim))
+        )
+        self.cls_token = add_parameter(
+            self, paddle.zeros((1, 1, embed_dim))
+        )
+
+        self.pos_drop = nn.Dropout(p=drop_rate)
+
+        dpr = np.linspace(0, drop_path_rate, depth)
+
+        self.blocks = nn.LayerList([
+            Block(
+                dim=embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                qk_scale=qk_scale,
+                drop=drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=dpr[i],
+                norm_layer=norm_layer,
+                epsilon=epsilon
+            )
+            for i in range(depth)
+        ])
+
+        self.norm = norm_layer(embed_dim, epsilon=epsilon)
+
+        # Classifier head
+        if class_dim > 0:
+            self.head = nn.Linear(embed_dim, class_dim)
+
+        if paddle.in_dynamic_mode():
+            trunc_normal_(self.pos_embed)
+            trunc_normal_(self.cls_token)
+            self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, nn.Linear):
+            trunc_normal_(m.weight)
+            if isinstance(m, nn.Linear) and m.bias is not None:
+                zeros_(m.bias)
+        elif isinstance(m, nn.LayerNorm):
+            zeros_(m.bias)
+            ones_(m.weight)
+
+    def forward_features(self, x):
+        B = paddle.shape(x)[0]
+        x = self.patch_embed(x)
+        cls_tokens = self.cls_token.expand((B, -1, -1))
+        x = paddle.concat((cls_tokens, x), axis=1)
+        x = x + self.pos_embed
+        x = self.pos_drop(x)
+        for blk in self.blocks:
+            x = blk(x)
+        x = self.norm(x)
+        return x[:, 0]
+
+    def forward(self, x):
+        x = self.forward_features(x)
+
+        if self.class_dim > 0:
+            x = self.head(x)
+
+        return x

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# 文档
+* [模型复现技巧](./model_reproduction_skills.md)
+* [常用功能模块](./utils.md)

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,0 +1,43 @@
+# 常用功能模块
+## 介绍
+* 在 utils 包中包含一些常用的功能模块
+* 下面为简单介绍，具体用法可以参考 Vision Transformer/vit.py
+## 网络层
+* Identity：占位层
+* DropPath：一种 Dropout 层
+
+    ```python
+    from utils import Identity
+    model = Identity()
+    ```
+
+## 常用函数
+* to_2tuple：int(x) -> (int(x), int(x))
+* add_parameter：创建可学习参数
+
+    ```python
+    # Paddle
+    from utils import add_parameter
+
+    class VisionTransformer(nn.Layer):
+        def __init__(self):
+            super().__init__()
+            self.pos_embed = add_parameter(self, paddle.zeros((1, num_patches + 1, embed_dim)))
+
+
+    # Pytorch
+    class VisionTransformer(nn.Layer):
+        def __init__(self):
+            super().__init__()
+            self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
+    ```
+
+## 常用初始化
+* ones_：全一初始化
+* zeros_：全零初始化
+* trunc_normal_：trunc_normal 初始化（std=0.2）
+
+    ```python
+    from utils import zeros_
+    zeros_(layer.bias)
+    ```

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from .common import *

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,0 +1,60 @@
+import paddle
+import paddle.nn as nn
+
+from paddle.nn.initializer import TruncatedNormal, KaimingNormal, Constant, Assign
+
+
+# Common initializations
+ones_ = Constant(value=1.)
+zeros_ = Constant(value=0.)
+kaiming_normal_ = KaimingNormal()
+trunc_normal_ = TruncatedNormal(std=.02)
+
+
+# Common Functions
+def to_2tuple(x):
+    return tuple([x] * 2)
+
+
+def add_parameter(layer, datas, name=None):
+    parameter = layer.create_parameter(
+        shape=(datas.shape),
+        default_initializer=Assign(datas)
+    )
+    if name:
+        layer.add_parameter(name, parameter)
+    return parameter
+
+
+# Common Layers
+def drop_path(x, drop_prob=0., training=False):
+    """
+        Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
+        the original name is misleading as 'Drop Connect' is a different form of dropout in a separate paper...
+        See discussion: https://github.com/tensorflow/tpu/issues/494#issuecomment-532968956 ...
+    """
+    if drop_prob == 0. or not training:
+        return x
+    keep_prob = paddle.to_tensor(1 - drop_prob)
+    shape = (paddle.shape(x)[0], ) + (1, ) * (x.ndim - 1)
+    random_tensor = keep_prob + paddle.rand(shape, dtype=x.dtype)
+    random_tensor = paddle.floor(random_tensor)  # binarize
+    output = x.divide(keep_prob) * random_tensor
+    return output
+
+
+class DropPath(nn.Layer):
+    def __init__(self, drop_prob=None):
+        super(DropPath, self).__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x):
+        return drop_path(x, self.drop_prob, self.training)
+
+
+class Identity(nn.Layer):
+    def __init__(self):
+        super(Identity, self).__init__()
+
+    def forward(self, input):
+        return input


### PR DESCRIPTION
把 vit 类的模型经常用的一些功能集合到了一起，包括 Identity、DropPath、创建参数和一些初始化操作，方便大家复现模型的时候使用